### PR TITLE
fix: align DsButton with Figma design specs

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,3 +1,7 @@
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '../src/styles/base.css';
 import type { Preview } from '@storybook/vue3-vite';
 import { setup } from '@storybook/vue3-vite';
 import PrimeVue from 'primevue/config';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "@failwin/desing-system-vue",
       "version": "0.1.2",
+      "dependencies": {
+        "@fontsource/inter": "^5.2.8"
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",
         "@primeuix/themes": "^2.0.3",
@@ -992,6 +995,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
   },
   "lint-staged": {
     "*.{js,ts,vue,css,json}": "biome check --write"
+  },
+  "dependencies": {
+    "@fontsource/inter": "^5.2.8"
   }
 }

--- a/src/components/DsButton/DsButton.test.ts
+++ b/src/components/DsButton/DsButton.test.ts
@@ -62,8 +62,9 @@ describe('DsButton', () => {
       const btn = wrapper.findComponent(Button);
       const dt = btn.props('dt') as Record<string, unknown>;
       expect(dt.fontSize).toBe('0.75rem');
-      expect(dt.paddingX).toBe('0.5rem');
-      expect(dt.paddingY).toBe('0.25rem');
+      expect(dt.paddingX).toBe('0.25rem');
+      expect(dt.paddingY).toBe('3px');
+      expect(dt.borderRadius).toBe('4px');
     });
 
     it('passes dt size tokens for small', () => {
@@ -74,8 +75,9 @@ describe('DsButton', () => {
       const btn = wrapper.findComponent(Button);
       const dt = btn.props('dt') as Record<string, unknown>;
       expect(dt.fontSize).toBe('0.875rem');
-      expect(dt.paddingX).toBe('0.75rem');
-      expect(dt.paddingY).toBe('0.375rem');
+      expect(dt.paddingX).toBe('2rem');
+      expect(dt.paddingY).toBe('5px');
+      expect(dt.borderRadius).toBe('8px');
     });
 
     it('passes dt size tokens for medium', () => {
@@ -86,8 +88,9 @@ describe('DsButton', () => {
       const btn = wrapper.findComponent(Button);
       const dt = btn.props('dt') as Record<string, unknown>;
       expect(dt.fontSize).toBe('0.875rem');
-      expect(dt.paddingX).toBe('1rem');
-      expect(dt.paddingY).toBe('0.5rem');
+      expect(dt.paddingX).toBe('2rem');
+      expect(dt.paddingY).toBe('7px');
+      expect(dt.borderRadius).toBe('8px');
     });
 
     it('passes dt size tokens for large', () => {
@@ -99,7 +102,30 @@ describe('DsButton', () => {
       const dt = btn.props('dt') as Record<string, unknown>;
       expect(dt.fontSize).toBe('0.875rem');
       expect(dt.paddingX).toBe('2rem');
-      expect(dt.paddingY).toBe('0.625rem');
+      expect(dt.paddingY).toBe('9px');
+      expect(dt.borderRadius).toBe('8px');
+    });
+  });
+
+  describe('typography per size', () => {
+    it.each([
+      ['xsmall', '400', 'normal', '16px'],
+      ['small', '500', '-0.2px', '20px'],
+      ['medium', '600', '-0.2px', '20px'],
+      ['large', '600', '-0.2px', '20px'],
+    ] as const)('applies correct font weight, letter spacing, line height for %s', (dsSize, expectedWeight, expectedSpacing, expectedLineHeight) => {
+      const wrapper = mount(DsButton, {
+        props: { size: dsSize },
+        global: globalConfig,
+      });
+      const style = wrapper.attributes('style') || '';
+      expect(style).toContain(`font-weight: ${expectedWeight}`);
+      if (expectedSpacing === 'normal') {
+        expect(style).toContain('letter-spacing: 0');
+      } else {
+        expect(style).toContain(`letter-spacing: ${expectedSpacing}`);
+      }
+      expect(style).toContain(`line-height: ${expectedLineHeight}`);
     });
   });
 

--- a/src/components/DsButton/DsButton.vue
+++ b/src/components/DsButton/DsButton.vue
@@ -18,6 +18,7 @@ interface ButtonSizeValues {
   paddingX: string;
   paddingY: string;
   iconOnlyWidth: string;
+  borderRadius: string;
 }
 
 interface ButtonSizeTokens extends ButtonSizeValues {
@@ -71,53 +72,60 @@ const mappedPrimeVueSize = computed(() => {
 });
 
 // Design token overrides per size for exact Figma dimensions
-// Heights achieved via paddingY: (targetHeight - fontSize * lineHeight) / 2
-// XS: (24 - 16) / 2 = 4px = 0.25rem
-// S:  (32 - 20) / 2 = 6px = 0.375rem
-// M:  (36 - 20) / 2 = 8px = 0.5rem
-// L:  (40 - 20) / 2 = 10px = 0.625rem
+// Heights achieved via paddingY: (targetHeight - lineHeight - 2px border) / 2
+// XS: (24 - 16 - 2) / 2 = 3px
+// S:  (32 - 20 - 2) / 2 = 5px
+// M:  (36 - 20 - 2) / 2 = 7px
+// L:  (40 - 20 - 2) / 2 = 9px
 const sizeTokens = computed((): ButtonSizeTokens => {
   const map: Record<string, ButtonSizeTokens> = {
     xsmall: {
       fontSize: '0.75rem',
-      paddingX: '0.5rem',
-      paddingY: '0.25rem',
+      paddingX: '0.25rem',
+      paddingY: '3px',
       iconOnlyWidth: '1.5rem',
+      borderRadius: '4px',
       sm: {
         fontSize: '0.75rem',
-        paddingX: '0.5rem',
-        paddingY: '0.25rem',
+        paddingX: '0.25rem',
+        paddingY: '3px',
         iconOnlyWidth: '1.5rem',
+        borderRadius: '4px',
       },
     },
     small: {
       fontSize: '0.875rem',
-      paddingX: '0.75rem',
-      paddingY: '0.375rem',
+      paddingX: '2rem',
+      paddingY: '5px',
       iconOnlyWidth: '2rem',
+      borderRadius: '8px',
       sm: {
         fontSize: '0.875rem',
-        paddingX: '0.75rem',
-        paddingY: '0.375rem',
+        paddingX: '2rem',
+        paddingY: '5px',
         iconOnlyWidth: '2rem',
+        borderRadius: '8px',
       },
     },
     medium: {
       fontSize: '0.875rem',
-      paddingX: '1rem',
-      paddingY: '0.5rem',
+      paddingX: '2rem',
+      paddingY: '7px',
       iconOnlyWidth: '2.25rem',
+      borderRadius: '8px',
     },
     large: {
       fontSize: '0.875rem',
       paddingX: '2rem',
-      paddingY: '0.625rem',
+      paddingY: '9px',
       iconOnlyWidth: '2.5rem',
+      borderRadius: '8px',
       lg: {
         fontSize: '0.875rem',
         paddingX: '2rem',
-        paddingY: '0.625rem',
+        paddingY: '9px',
         iconOnlyWidth: '2.5rem',
+        borderRadius: '8px',
       },
     },
   };
@@ -131,6 +139,17 @@ const iconSize = computed(() => {
     small: '1rem',
     medium: '1.25rem',
     large: '1.25rem',
+  };
+  return map[props.size];
+});
+
+// Font weight per size tier (Figma: XS=400, S=500, M/L=600)
+const fontWeight = computed(() => {
+  const map: Record<string, string> = {
+    xsmall: '400',
+    small: '500',
+    medium: '600',
+    large: '600',
   };
   return map[props.size];
 });
@@ -154,12 +173,17 @@ const buttonClasses = computed(() => ({
     :dt="sizeTokens"
     :disabled="disabled"
     :class="buttonClasses"
-    :style="{ '--ds-button-icon-size': iconSize }"
+    :style="{
+      '--ds-button-icon-size': iconSize,
+      fontWeight,
+      letterSpacing: props.size === 'xsmall' ? '0' : '-0.2px',
+      lineHeight: props.size === 'xsmall' ? '16px' : '20px',
+    }"
     :aria-disabled="disabled ? 'true' : undefined"
     :aria-busy="loading ? 'true' : undefined"
     :aria-live="loading ? 'polite' : undefined"
   >
-    <template #icon>
+    <template v-if="$slots.icon" #icon>
       <slot name="icon" />
     </template>
     <slot />
@@ -237,5 +261,9 @@ const buttonClasses = computed(() => ({
   font-size: var(--ds-button-icon-size);
   width: var(--ds-button-icon-size);
   height: var(--ds-button-icon-size);
+}
+
+.ds-button--medium {
+  font-size: var(--p-button-font-size) !important;
 }
 </style>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import './styles/base.css';
+
 // Barrel export — component re-exports will be added here
 export { DsButton, type DsButtonProps } from './components/DsButton';
 export { DsIcon, type IconName } from './components/DsIcon';

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,0 +1,3 @@
+body {
+  font-family: var(--p-font-family-body, "Inter", sans-serif);
+}


### PR DESCRIPTION
## Summary
- Fix DsButton padding, border-radius, font-weight, font-size, letter-spacing, line-height, and heights to match Figma design specs exactly
- Add Inter font loading via `@fontsource/inter` (weights 400/500/600) and `base.css` to apply it globally
- Fix PrimeVue `p-button-icon-only` incorrectly applied by conditionally forwarding the `#icon` slot

## Changes
| Property | Before | After (Figma) |
|----------|--------|---------------|
| Horizontal padding (S/M) | 12px / 16px | 32px |
| Border radius (S/M/L) | 4px | 8px |
| Font weight (M/L / S / XS) | 400 | 600 / 500 / 400 |
| Font size (M) | 16px | 14px |
| Letter spacing (S/M/L) | normal | -0.2px |
| Line height | browser default | 20px (16px for XS) |
| Heights (XS/S/M/L) | off by 1-2px | 24/32/36/40px exact |
| Font family | system fallback | Inter via @fontsource |

## Test plan
- [x] All 38 DsButton unit tests pass (`vitest run`)
- [ ] Visual review in Storybook: All Sizes, All Variants, With Left/Right Icon stories
- [ ] Verify Inter font renders in Storybook and consumer apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)