### PR TITLE
fix: align DsIconButton with Figma design specs

### DIFF
--- a/src/components/DsIconButton/DsIconButton.stories.ts
+++ b/src/components/DsIconButton/DsIconButton.stories.ts
@@ -17,6 +17,8 @@ const meta = {
     },
     disabled: { control: 'boolean' },
     loading: { control: 'boolean' },
+    indicator: { control: 'boolean' },
+    counterBadge: { control: 'number' },
     ariaLabel: { control: 'text' },
   },
   args: {
@@ -24,6 +26,7 @@ const meta = {
     size: 'medium',
     disabled: false,
     loading: false,
+    indicator: false,
     ariaLabel: 'Edit',
   },
 } satisfies Meta<typeof DsIconButton>;
@@ -76,7 +79,20 @@ export const Text: Story = {
 };
 
 export const Disabled: Story = {
-  args: { disabled: true },
+  render: () => ({
+    components: { DsIconButton, DsIcon },
+    template: `
+      <div style="display: flex; align-items: center; gap: 12px;">
+        <DsIconButton type="primary" disabled ariaLabel="Edit"><DsIcon name="edit" /></DsIconButton>
+        <DsIconButton type="outlined" disabled ariaLabel="Edit"><DsIcon name="edit" /></DsIconButton>
+        <DsIconButton type="text" disabled ariaLabel="Edit"><DsIcon name="edit" /></DsIconButton>
+      </div>
+    `,
+  }),
+};
+
+export const Loading: Story = {
+  args: { loading: true },
   render: (args) => ({
     components: { DsIconButton, DsIcon },
     setup() {
@@ -90,8 +106,23 @@ export const Disabled: Story = {
   }),
 };
 
-export const Loading: Story = {
-  args: { loading: true },
+export const WithIndicator: Story = {
+  args: { type: 'text', size: 'xsmall', indicator: true },
+  render: (args) => ({
+    components: { DsIconButton, DsIcon },
+    setup() {
+      return { args };
+    },
+    template: `
+      <DsIconButton v-bind="args">
+        <DsIcon name="edit" size="xsmall" />
+      </DsIconButton>
+    `,
+  }),
+};
+
+export const WithCounterBadge: Story = {
+  args: { type: 'text', size: 'medium', counterBadge: 9 },
   render: (args) => ({
     components: { DsIconButton, DsIcon },
     setup() {

--- a/src/components/DsIconButton/DsIconButton.test.ts
+++ b/src/components/DsIconButton/DsIconButton.test.ts
@@ -10,14 +10,24 @@ const globalConfig = {
 
 const defaultProps = { ariaLabel: 'Action' };
 
+/** Helper: find the PrimeVue Button inside the wrapper */
+function findBtn(wrapper: ReturnType<typeof mount>) {
+  return wrapper.findComponent(Button);
+}
+
 describe('DsIconButton', () => {
   it('renders with default props (primary, medium)', () => {
     const wrapper = mount(DsIconButton, { props: defaultProps, global: globalConfig });
-    const btn = wrapper.findComponent(Button);
+    const btn = findBtn(wrapper);
     expect(btn.exists()).toBe(true);
-    expect(wrapper.classes()).toContain('ds-icon-button');
-    expect(wrapper.classes()).toContain('ds-icon-button--primary');
-    expect(wrapper.classes()).toContain('ds-icon-button--medium');
+    expect(btn.classes()).toContain('ds-icon-button');
+    expect(btn.classes()).toContain('ds-icon-button--primary');
+    expect(btn.classes()).toContain('ds-icon-button--medium');
+  });
+
+  it('renders a wrapper div with ds-icon-button-wrapper class', () => {
+    const wrapper = mount(DsIconButton, { props: defaultProps, global: globalConfig });
+    expect(wrapper.find('.ds-icon-button-wrapper').exists()).toBe(true);
   });
 
   describe('type variants', () => {
@@ -30,10 +40,10 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, type: dsType },
         global: globalConfig,
       });
-      const btn = wrapper.findComponent(Button);
+      const btn = findBtn(wrapper);
       expect(btn.props('severity')).toBe(expectedSeverity);
       expect(btn.props('variant')).toBe(expectedVariant);
-      expect(wrapper.classes()).toContain(`ds-icon-button--${dsType}`);
+      expect(btn.classes()).toContain(`ds-icon-button--${dsType}`);
     });
   });
 
@@ -47,9 +57,9 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, size: dsSize },
         global: globalConfig,
       });
-      const btn = wrapper.findComponent(Button);
+      const btn = findBtn(wrapper);
       expect(btn.props('size')).toBe(expectedPvSize);
-      expect(wrapper.classes()).toContain(`ds-icon-button--${dsSize}`);
+      expect(btn.classes()).toContain(`ds-icon-button--${dsSize}`);
     });
 
     it('passes dt size tokens for xsmall', () => {
@@ -57,7 +67,7 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, size: 'xsmall' },
         global: globalConfig,
       });
-      const btn = wrapper.findComponent(Button);
+      const btn = findBtn(wrapper);
       const dt = btn.props('dt') as Record<string, unknown>;
       expect(dt.fontSize).toBe('0');
       expect(dt.paddingX).toBe('0');
@@ -71,7 +81,7 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, size: 'small' },
         global: globalConfig,
       });
-      const btn = wrapper.findComponent(Button);
+      const btn = findBtn(wrapper);
       const dt = btn.props('dt') as Record<string, unknown>;
       expect(dt.fontSize).toBe('0');
       expect(dt.paddingX).toBe('0');
@@ -85,7 +95,7 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, size: 'medium' },
         global: globalConfig,
       });
-      const btn = wrapper.findComponent(Button);
+      const btn = findBtn(wrapper);
       const dt = btn.props('dt') as Record<string, unknown>;
       expect(dt.fontSize).toBe('0');
       expect(dt.paddingX).toBe('0');
@@ -96,14 +106,15 @@ describe('DsIconButton', () => {
   });
 
   describe('disabled state', () => {
-    it('applies disabled class, aria-disabled, and removes transitions', () => {
+    it('applies disabled class and aria-disabled on the button', () => {
       const wrapper = mount(DsIconButton, {
         props: { ...defaultProps, disabled: true },
         global: globalConfig,
       });
-      expect(wrapper.classes()).toContain('ds-icon-button--disabled');
-      expect(wrapper.classes()).not.toContain('ds-icon-button--transitions');
-      expect(wrapper.attributes('aria-disabled')).toBe('true');
+      const btn = findBtn(wrapper);
+      expect(btn.classes()).toContain('ds-icon-button--disabled');
+      expect(btn.classes()).not.toContain('ds-icon-button--transitions');
+      expect(btn.attributes('aria-disabled')).toBe('true');
     });
 
     it('passes disabled to the rendered button element', () => {
@@ -117,8 +128,39 @@ describe('DsIconButton', () => {
 
     it('has transitions when not disabled', () => {
       const wrapper = mount(DsIconButton, { props: defaultProps, global: globalConfig });
-      expect(wrapper.classes()).toContain('ds-icon-button--transitions');
-      expect(wrapper.classes()).not.toContain('ds-icon-button--disabled');
+      const btn = findBtn(wrapper);
+      expect(btn.classes()).toContain('ds-icon-button--transitions');
+      expect(btn.classes()).not.toContain('ds-icon-button--disabled');
+    });
+
+    it('applies per-type disabled class for primary', () => {
+      const wrapper = mount(DsIconButton, {
+        props: { ...defaultProps, type: 'primary', disabled: true },
+        global: globalConfig,
+      });
+      const btn = findBtn(wrapper);
+      expect(btn.classes()).toContain('ds-icon-button--primary');
+      expect(btn.classes()).toContain('ds-icon-button--disabled');
+    });
+
+    it('applies per-type disabled class for outlined', () => {
+      const wrapper = mount(DsIconButton, {
+        props: { ...defaultProps, type: 'outlined', disabled: true },
+        global: globalConfig,
+      });
+      const btn = findBtn(wrapper);
+      expect(btn.classes()).toContain('ds-icon-button--outlined');
+      expect(btn.classes()).toContain('ds-icon-button--disabled');
+    });
+
+    it('applies per-type disabled class for text', () => {
+      const wrapper = mount(DsIconButton, {
+        props: { ...defaultProps, type: 'text', disabled: true },
+        global: globalConfig,
+      });
+      const btn = findBtn(wrapper);
+      expect(btn.classes()).toContain('ds-icon-button--text');
+      expect(btn.classes()).toContain('ds-icon-button--disabled');
     });
   });
 
@@ -132,10 +174,10 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, size: dsSize },
         global: globalConfig,
       });
-      const btn = wrapper.findComponent(Button);
+      const btn = findBtn(wrapper);
       const dt = btn.props('dt') as Record<string, unknown>;
       expect(dt.iconOnlyWidth).toBe(expectedDimension);
-      const style = wrapper.attributes('style') || '';
+      const style = btn.attributes('style') || '';
       expect(style).toContain(`--ds-icon-button-dimension: ${expectedDimension}`);
     });
   });
@@ -161,7 +203,8 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, loading: true },
         global: globalConfig,
       });
-      expect(wrapper.classes()).toContain('ds-icon-button--loading');
+      const btn = findBtn(wrapper);
+      expect(btn.classes()).toContain('ds-icon-button--loading');
     });
 
     it('disables the button when loading to prevent keyboard activation', () => {
@@ -178,12 +221,14 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, loading: true },
         global: globalConfig,
       });
-      expect(wrapper.attributes('aria-live')).toBe('polite');
+      const btn = findBtn(wrapper);
+      expect(btn.attributes('aria-live')).toBe('polite');
     });
 
     it('does not have aria-live when not loading', () => {
       const wrapper = mount(DsIconButton, { props: defaultProps, global: globalConfig });
-      expect(wrapper.attributes('aria-live')).toBeUndefined();
+      const btn = findBtn(wrapper);
+      expect(btn.attributes('aria-live')).toBeUndefined();
     });
 
     it('adds aria-busy="true" when loading', () => {
@@ -191,12 +236,14 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, loading: true },
         global: globalConfig,
       });
-      expect(wrapper.attributes('aria-busy')).toBe('true');
+      const btn = findBtn(wrapper);
+      expect(btn.attributes('aria-busy')).toBe('true');
     });
 
     it('does not have aria-busy when not loading', () => {
       const wrapper = mount(DsIconButton, { props: defaultProps, global: globalConfig });
-      expect(wrapper.attributes('aria-busy')).toBeUndefined();
+      const btn = findBtn(wrapper);
+      expect(btn.attributes('aria-busy')).toBeUndefined();
     });
 
     it('hides icon slot when loading', () => {
@@ -231,7 +278,8 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, loading: true },
         global: globalConfig,
       });
-      expect(wrapper.attributes('aria-disabled')).toBe('true');
+      const btn = findBtn(wrapper);
+      expect(btn.attributes('aria-disabled')).toBe('true');
     });
 
     it('removes transitions when loading', () => {
@@ -239,7 +287,8 @@ describe('DsIconButton', () => {
         props: { ...defaultProps, loading: true },
         global: globalConfig,
       });
-      expect(wrapper.classes()).not.toContain('ds-icon-button--transitions');
+      const btn = findBtn(wrapper);
+      expect(btn.classes()).not.toContain('ds-icon-button--transitions');
     });
   });
 
@@ -311,6 +360,71 @@ describe('DsIconButton', () => {
         global: globalConfig,
       });
       expect(wrapper.find('#my-icon-button').exists()).toBe(true);
+    });
+  });
+
+  describe('indicator', () => {
+    it('renders indicator dot when indicator=true', () => {
+      const wrapper = mount(DsIconButton, {
+        props: { ...defaultProps, indicator: true },
+        global: globalConfig,
+      });
+      expect(wrapper.find('.ds-icon-button-indicator').exists()).toBe(true);
+    });
+
+    it('hides indicator by default', () => {
+      const wrapper = mount(DsIconButton, {
+        props: defaultProps,
+        global: globalConfig,
+      });
+      expect(wrapper.find('.ds-icon-button-indicator').exists()).toBe(false);
+    });
+
+    it('indicator is aria-hidden', () => {
+      const wrapper = mount(DsIconButton, {
+        props: { ...defaultProps, indicator: true },
+        global: globalConfig,
+      });
+      expect(wrapper.find('.ds-icon-button-indicator').attributes('aria-hidden')).toBe('true');
+    });
+
+    it('indicator is hidden when counterBadge is also set', () => {
+      const wrapper = mount(DsIconButton, {
+        props: { ...defaultProps, indicator: true, counterBadge: 3 },
+        global: globalConfig,
+      });
+      expect(wrapper.find('.ds-icon-button-indicator').exists()).toBe(false);
+      expect(wrapper.find('.ds-icon-button-counter-badge').exists()).toBe(true);
+    });
+  });
+
+  describe('counterBadge', () => {
+    it('renders counter badge with value', () => {
+      const wrapper = mount(DsIconButton, {
+        props: { ...defaultProps, counterBadge: 9 },
+        global: globalConfig,
+      });
+      const badge = wrapper.find('.ds-icon-button-counter-badge');
+      expect(badge.exists()).toBe(true);
+      expect(badge.text()).toBe('9');
+    });
+
+    it('does not render counter badge by default', () => {
+      const wrapper = mount(DsIconButton, {
+        props: defaultProps,
+        global: globalConfig,
+      });
+      expect(wrapper.find('.ds-icon-button-counter-badge').exists()).toBe(false);
+    });
+
+    it('counter badge has accessible label', () => {
+      const wrapper = mount(DsIconButton, {
+        props: { ...defaultProps, counterBadge: 5 },
+        global: globalConfig,
+      });
+      expect(wrapper.find('.ds-icon-button-counter-badge').attributes('aria-label')).toBe(
+        '5 notifications',
+      );
     });
   });
 });

--- a/src/components/DsIconButton/DsIconButton.vue
+++ b/src/components/DsIconButton/DsIconButton.vue
@@ -11,6 +11,10 @@ export interface DsIconButtonProps {
   disabled?: boolean;
   /** Loading state. Default: false */
   loading?: boolean;
+  /** Show filter indicator dot at top-right corner. Default: false */
+  indicator?: boolean;
+  /** Counter badge value. When set, shows a count badge at top-right. */
+  counterBadge?: number;
   /** Accessible label (required for icon-only buttons unless ariaLabelledby is provided) */
   ariaLabel?: string;
   /** ID of an element that labels this button (alternative to ariaLabel) */
@@ -24,6 +28,7 @@ const props = withDefaults(defineProps<DsIconButtonProps>(), {
   size: 'medium',
   disabled: false,
   loading: false,
+  indicator: false,
 });
 
 // Map DsIconButton type to PrimeVue variant
@@ -98,42 +103,142 @@ const buttonClasses = computed(() => ({
 </script>
 
 <template>
-  <Button
-    v-bind="$attrs"
-    :variant="mappedVariant"
-    :size="mappedPrimeVueSize"
-    :dt="sizeTokens"
-    :disabled="disabled || loading"
-    :class="buttonClasses"
-    :style="{
-      '--ds-icon-button-icon-size': iconSize,
-      '--ds-icon-button-dimension': buttonDimension,
-    }"
-    :aria-label="ariaLabel"
-    :aria-labelledby="ariaLabelledby"
-    :aria-disabled="(disabled || loading) ? 'true' : undefined"
-    :aria-busy="loading ? 'true' : undefined"
-    :aria-live="loading ? 'polite' : undefined"
-  >
-    <span v-if="!loading && $slots.default" class="ds-icon-button-icon">
-      <slot />
-    </span>
-    <span v-else-if="loading" class="ds-icon-button-loading-overlay" role="status" aria-label="Loading">
-      <span class="ds-icon-button-loading-dots">
-        <span /><span /><span />
+  <div class="ds-icon-button-wrapper">
+    <Button
+      v-bind="$attrs"
+      :variant="mappedVariant"
+      :size="mappedPrimeVueSize"
+      :dt="sizeTokens"
+      :disabled="disabled || loading"
+      :class="buttonClasses"
+      :style="{
+        '--ds-icon-button-icon-size': iconSize,
+        '--ds-icon-button-dimension': buttonDimension,
+      }"
+      :aria-label="ariaLabel"
+      :aria-labelledby="ariaLabelledby"
+      :aria-disabled="(disabled || loading) ? 'true' : undefined"
+      :aria-busy="loading ? 'true' : undefined"
+      :aria-live="loading ? 'polite' : undefined"
+    >
+      <span v-if="!loading && $slots.default" class="ds-icon-button-icon">
+        <slot />
       </span>
+      <span v-else-if="loading" class="ds-icon-button-loading-overlay" role="status" aria-label="Loading">
+        <span class="ds-icon-button-loading-dots">
+          <span /><span /><span />
+        </span>
+      </span>
+    </Button>
+    <span
+      v-if="indicator && !counterBadge"
+      class="ds-icon-button-indicator"
+      aria-hidden="true"
+    />
+    <span
+      v-if="counterBadge != null"
+      class="ds-icon-button-counter-badge"
+      :aria-label="`${counterBadge} notifications`"
+    >
+      {{ counterBadge }}
     </span>
-  </Button>
+  </div>
 </template>
 
 <style scoped>
+/* Wrapper for positioning indicator / counter badge */
+.ds-icon-button-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
 .ds-icon-button--transitions {
   transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease, box-shadow 150ms ease, opacity 150ms ease;
 }
 
+/* ------------------------------------------------------------------ */
+/* Disabled – per-type styling (Figma uses distinct colors, not opacity)*/
+/* ------------------------------------------------------------------ */
 .ds-icon-button--disabled {
-  opacity: 0.5;
   pointer-events: none;
+}
+
+/* Primary disabled: solid gray-300 bg, gray-500 icon */
+.ds-icon-button--primary.ds-icon-button--disabled {
+  background-color: var(--p-gray-300, #e2e8f0) !important;
+  border-color: var(--p-gray-300, #e2e8f0) !important;
+  color: var(--p-gray-500, #90a1b9) !important;
+}
+
+/* Outlined disabled: gray-300 border, gray-400 icon */
+.ds-icon-button--outlined.ds-icon-button--disabled {
+  background-color: var(--p-surface-0, #ffffff) !important;
+  border-color: var(--p-gray-300, #e2e8f0) !important;
+  color: var(--p-gray-400, #cad5e2) !important;
+  opacity: 1;
+}
+
+/* Text disabled: muted icon */
+.ds-icon-button--text.ds-icon-button--disabled {
+  color: var(--p-gray-400, #cad5e2) !important;
+  background-color: transparent !important;
+  opacity: 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Hover states (Figma-exact colors)                                   */
+/* ------------------------------------------------------------------ */
+
+/* Primary hover: purple-800 */
+.ds-icon-button--primary:not(.ds-icon-button--disabled):hover {
+  background-color: var(--p-primary-800, #5f33e6) !important;
+  border-color: var(--p-primary-800, #5f33e6) !important;
+}
+
+/* Outlined hover: gray-200 inner bg */
+.ds-icon-button--outlined:not(.ds-icon-button--disabled):hover {
+  background-color: var(--p-gray-200, #f1f5f9) !important;
+  border-color: var(--p-gray-400, #cad5e2) !important;
+}
+
+/* Text hover: gray-200 bg */
+.ds-icon-button--text:not(.ds-icon-button--disabled):hover {
+  background-color: var(--p-gray-200, #f1f5f9) !important;
+}
+
+/* ------------------------------------------------------------------ */
+/* Active / pressed states                                             */
+/* ------------------------------------------------------------------ */
+
+/* Primary active: purple-800 */
+.ds-icon-button--primary:not(.ds-icon-button--disabled):active {
+  background-color: var(--p-primary-800, #5f33e6) !important;
+  border-color: var(--p-primary-800, #5f33e6) !important;
+}
+
+/* Outlined active: gray-200 fill */
+.ds-icon-button--outlined:not(.ds-icon-button--disabled):active {
+  background-color: var(--p-gray-200, #f1f5f9) !important;
+}
+
+/* Text active: gray-300 fill */
+.ds-icon-button--text:not(.ds-icon-button--disabled):active {
+  background-color: var(--p-gray-300, #e2e8f0) !important;
+}
+
+/* ------------------------------------------------------------------ */
+/* Outlined border color per size (Figma: XS/M = gray-400, S = gray-300) */
+/* ------------------------------------------------------------------ */
+.ds-icon-button--outlined.ds-icon-button--xsmall {
+  border-color: var(--p-gray-400, #cad5e2);
+}
+
+.ds-icon-button--outlined.ds-icon-button--small {
+  border-color: var(--p-gray-300, #e2e8f0);
+}
+
+.ds-icon-button--outlined.ds-icon-button--medium {
+  border-color: var(--p-gray-400, #cad5e2);
 }
 
 .ds-icon-button--loading {
@@ -164,6 +269,42 @@ const buttonClasses = computed(() => ({
   width: var(--ds-icon-button-icon-size);
   height: var(--ds-icon-button-icon-size);
   font-size: var(--ds-icon-button-icon-size);
+  pointer-events: none;
+}
+
+/* ------------------------------------------------------------------ */
+/* Indicator dot (Figma: 5px circle at top-right)                      */
+/* ------------------------------------------------------------------ */
+.ds-icon-button-indicator {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background-color: var(--p-primary-600, #7849ff);
+  pointer-events: none;
+}
+
+/* ------------------------------------------------------------------ */
+/* Counter badge (Figma: 20px circle at top-right offset)              */
+/* ------------------------------------------------------------------ */
+.ds-icon-button-counter-badge {
+  position: absolute;
+  top: -3px;
+  right: -6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 100px;
+  background-color: var(--p-primary-600, #7849ff);
+  color: #ffffff;
+  font-family: var(--p-font-family, 'Inter', sans-serif);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- **Disabled states**: Replaced generic `opacity: 0.5` with per-type Figma-accurate colors (primary→gray-300 bg, outlined→gray-300 border, text→gray-400 icon)
- **Hover/active states**: Added CSS overrides matching exact Figma tokens (primary→purple-800, outlined→gray-200 bg, text→gray-200/gray-300 bg)
- **Outlined border color per size**: XS/M use gray-400, S uses gray-300 per Figma spec
- **New `indicator` prop**: 5px purple dot at top-right corner (filter indicator from Figma)
- **New `counterBadge` prop**: 20px numbered badge at top-right with accessible label
- **Wrapper div**: Added for positioning indicator/badge relative to button

## Test plan
- [x] All 47 DsIconButton unit tests pass
- [x] Full test suite passes (173 tests)
- [ ] Visual review in Storybook: Primary, Outlined, Text, Disabled, WithIndicator, WithCounterBadge stories
- [ ] Verify hover/active states match Figma in browser
- [ ] Check disabled states render with correct gray colors (not opacity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)