### PR TITLE
fix: align DsInputText with Figma design specs

### DIFF
--- a/src/components/DsInputText/DsInputText.test.ts
+++ b/src/components/DsInputText/DsInputText.test.ts
@@ -338,6 +338,37 @@ describe('DsInputText', () => {
     });
   });
 
+  describe('filled state', () => {
+    it('applies filled class when modelValue has a value', () => {
+      const wrapper = mount(DsInputText, {
+        props: { modelValue: 'hello' },
+        global: globalConfig,
+      });
+      expect(wrapper.find('.ds-input-text__input--filled').exists()).toBe(true);
+    });
+
+    it('does not apply filled class when modelValue is empty', () => {
+      const wrapper = mount(DsInputText, {
+        props: { modelValue: '' },
+        global: globalConfig,
+      });
+      expect(wrapper.find('.ds-input-text__input--filled').exists()).toBe(false);
+    });
+
+    it('does not apply filled class when no modelValue is provided', () => {
+      const wrapper = mount(DsInputText, { global: globalConfig });
+      expect(wrapper.find('.ds-input-text__input--filled').exists()).toBe(false);
+    });
+
+    it('does not apply filled class when disabled even with value', () => {
+      const wrapper = mount(DsInputText, {
+        props: { disabled: true, modelValue: 'hello' },
+        global: globalConfig,
+      });
+      expect(wrapper.find('.ds-input-text__input--filled').exists()).toBe(false);
+    });
+  });
+
   describe('v-model', () => {
     it('supports two-way binding via v-model', async () => {
       const wrapper = mount(DsInputText, {

--- a/src/components/DsInputText/DsInputText.vue
+++ b/src/components/DsInputText/DsInputText.vue
@@ -56,6 +56,7 @@ const inputClasses = computed(() => ({
   [`ds-input-text__input--${props.size}`]: true,
   'ds-input-text__input--error': showError.value,
   'ds-input-text__input--disabled': props.disabled,
+  'ds-input-text__input--filled': hasValue.value && !props.disabled,
   'ds-input-text__input--transitions': !props.disabled,
 }));
 
@@ -255,27 +256,40 @@ function handleClear() {
   box-shadow: none;
 }
 
-/* Error state */
+/* Error state — border always red */
 .ds-input-text__input--error {
   border-color: var(--p-red-700);
+}
+
+/* Error + filled (Alert): no shadow */
+.ds-input-text__input--error.ds-input-text__input--filled {
   box-shadow: none;
 }
 
+/* Error + focused (Alert-Input): red ring */
 .ds-input-text__input--error:focus-within {
   box-shadow: 0px 0px 0px 3px var(--p-red-100);
 }
 
-/* Disabled state */
+/* Disabled state — no opacity; use muted colors per Figma */
 .ds-input-text__input--disabled {
   background-color: var(--p-gray-100);
   border-color: var(--p-gray-400);
   box-shadow: none;
-  opacity: 0.5;
   pointer-events: none;
+}
+
+.ds-input-text__input--disabled .ds-input-text__native {
+  color: var(--p-gray-500);
 }
 
 .ds-input-text__input--disabled .ds-input-text__native::placeholder {
   color: var(--p-gray-500);
+}
+
+/* Filled state (has value, idle) — no shadow per Figma */
+.ds-input-text__input--filled:not(.ds-input-text__input--error):not(.ds-input-text__input--disabled) {
+  box-shadow: none;
 }
 
 /* Transitions */
@@ -290,6 +304,10 @@ function handleClear() {
   justify-content: center;
   flex-shrink: 0;
   color: var(--p-gray-600);
+}
+
+.ds-input-text__input--disabled .ds-input-text__leading {
+  color: var(--p-gray-500);
 }
 
 /* Trailing elements */


### PR DESCRIPTION
## Summary
- **Disabled state**: Replaced `opacity: 0.5` with Figma's color-based approach (`gray-500` text/icons, `gray-100` bg) — no opacity reduction
- **Filled state**: Added `--filled` CSS class to remove `box-shadow` when input has a value (idle), matching Figma's Filled state
- **Error shadow logic**: Error + empty (Skip) keeps default shadow; error + filled (Alert) removes shadow; error + focused shows red ring
- **Disabled leading icon**: Dimmed to `gray-500` per Figma spec
- **Tests**: Added 4 new unit tests for filled state class behavior (44 total, all passing)

## Test plan
- [x] All 44 unit tests pass (`vitest run`)
- [ ] Verify default state visually in Storybook (shadow present)
- [ ] Verify filled state removes shadow when value is entered
- [ ] Verify hover on filled input shows correct bg/border
- [ ] Verify disabled state uses muted colors without opacity
- [ ] Verify error + empty keeps default shadow
- [ ] Verify error + filled has no shadow
- [ ] Verify error + focused shows red ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)