### PR TITLE
Add Storybook URL to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,10 @@
 
 A Vue 3 design system built on PrimeVue 4 and Tailwind CSS 4, published as `@failwin/desing-system-vue`.
 
+## Storybook
+
+[View Storybook](https://koval-yurko.github.io/desing-system-vue/)
+
 ## Adding Components
 
 See [docs/component-addition-guide.md](docs/component-addition-guide.md) for the step-by-step pattern to add new PrimeVue wrapper or custom Tailwind components to this library.


### PR DESCRIPTION
Add a Storybook section to Readme.md with a link to the GitHub Pages Storybook deployment for quick access from the repo page.

Closes #7

Generated with [Claude Code](https://claude.ai/code)